### PR TITLE
Change data request time period

### DIFF
--- a/ndbc_process_data.py
+++ b/ndbc_process_data.py
@@ -460,7 +460,7 @@ if __name__ == '__main__':
 
     # Get the last 24-hours of data
     currentTime = dt.datetime.now(tz=pytz.UTC)
-    startTime = currentTime - dt.timedelta(days=1)
+    startTime = currentTime - dt.timedelta(hours=2)
     timestamp = currentTime.strftime('%Y%m%d%H%M%S')
 
     # =========================================================================


### PR DESCRIPTION
Following correspondence with NDBC, I changed the time period for the data request from the past day to the past 2 hours. This is to cut down on "spam" messaging to the NDBC data server.